### PR TITLE
feat: refactor module in ts and bump warp version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,29 +34,35 @@ To enter a live-reload development session, use the command below. Feel free to 
 npm run start
 ```
 
+Note that when running this command, you have to select a project. On the ScaleDynamics platform, a project identifies an application or a microservice. If you are logged, select an existing project or create a new one. Else, you can use the platform anonymously. For more details on projects, see the [documentation](https://docs.scaledynamics.com).
+
 #### Deploy with ScaleDynamics
 
-First you have to compile and minify your project for production.
+First, you need to compile your typescript in to js.
+
+```sh
+npm run ts-build
+```
+
+Then you have to compile and minify your project for production.
 
 ```sh
 npm run build
 ```
 
-Then use your ScaleDynamics account credential to log in to the platform (create a FREE community account [here](https://console.scaledynamics.com/auth/signup/))
+Use your ScaleDynamics account credential to log in to the platform (create a FREE community account [here](https://console.scaledynamics.com/auth/signup/)).
 
 ```ssh
 npx warp login
 ```
 
-Finally, use the deploy command
+Finally, use the deploy command.
 
 ```sh
 npm run deploy
 ```
 
-Note that when running this command, you have to select a project and an environment. On the ScaleDynamics platform a project identifies an application or a microservice.
-
-Select an existing project or create a new one. An environment identifies the cloud execution environment to run your app. You can create as many as you want like ‘staging’, ‘demo’, ‘prod’... Each environment has its own url.
+Note that when running this command, you have to select an environment. An environment identifies the cloud execution environment to run your app. You can create as many as you want like ‘staging’, ‘demo’, ‘prod’... Each environment has its own url.
 
 To deploy, select an existing environment or create a new one. For more details on projects or environments, see the [documentation](https://docs.scaledynamics.com).
 
@@ -64,19 +70,19 @@ To deploy, select an existing environment or create a new one. For more details 
 
 This project is divided in two parts:
   - the frontend, a `angular-app` web template app created with `angular-cli`. To update it, open the `src` folder where you can add, modify or delete components.
-  - the backend with a node module and a MongoDB module. You can update the frontend/backend as you need to build your own app.
+  - the backend with a TypeScript node and MongoDB module. You can update the frontend/backend as you need to build your own app.
 
-Regarding MongoDB, we provide a template module  in the `src/mongodb.js`. To use your own MongoDB instance, replace the `URI` constant by your own.
+Regarding MongoDB, we provide a template module  in the `src/mongodb.ts`. To use your own MongoDB instance, replace the `URI` constant by your own.
 
-```js
+```ts
 const URI = 'mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]';
 ```
 
 
-You can create new functions that can be called by the frontend. Add them in `index.js` or into another module and export it. The platform manages the [Express](https://expressjs.com/) layers automatically.
+You can create new functions that can be called by the frontend. Add them in `src/index.ts` or into another module and export it. The platform manages the [Express](https://expressjs.com/) layers automatically.
 
 
-```js
+```ts
 const myFunction = () => {
   // your code here
 }

--- a/angular-app/angular.json
+++ b/angular-app/angular.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "cli": {
+    "analytics": false
+  },
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {

--- a/angular-app/package.json
+++ b/angular-app/package.json
@@ -4,13 +4,15 @@
   "scripts": {
     "postinstall": "cd ../backend/ && npm install",
     "ng": "ng",
+    "prestart": "npx warp project select && cd ../backend/ && npm run ts-build",
+    "start:watch": "cd ../backend/ && npm run ts-watch",
     "start:client": "ng serve",
     "start:server": "warp dev ../backend/",
     "start": "run-p start:*",
+    "ts-build": "cd ../backend/ && npm run ts-build",
     "build:client": "ng build",
     "build:server": "warp build ../backend/",
     "build": "run-s build:server build:client",
-    "predeploy": "warp project select",
     "deploy": "warp deploy ./ ../backend/",
     "test": "ng test",
     "lint": "ng lint",
@@ -26,7 +28,7 @@
     "@angular/platform-browser": "~11.2.11",
     "@angular/platform-browser-dynamic": "~11.2.11",
     "@angular/router": "~11.2.11",
-    "@warpjs/engine": "^4.0.9",
+    "@warpjs/engine": "^4.0.11",
     "rxjs": "~6.6.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.3"
@@ -51,6 +53,6 @@
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
     "typescript": "~4.1.5",
-    "warp": "^4.0.9"
+    "warp": "^4.0.11"
   }
 }

--- a/angular-app/src/app/app.component.ts
+++ b/angular-app/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 import Backend from 'backend';
-const { hello, fetchMovies } = new Backend() as any;
+const backend = new Backend();
 
 @Component({
   selector: 'app-root',
@@ -14,13 +14,13 @@ export class AppComponent implements OnInit {
   movies = {};
 
   ngOnInit() {
-    hello().then((msg: string) => {
+    backend.hello().then((msg: string) => {
       this.message = msg;
     });
 
     // fetchMovies from mongodb
-    fetchMovies('Star Trek').then(
-      (data: any) => (this.movies = JSON.stringify(data, null, 2))
-    );
+    backend
+      .fetchMovies('Star Trek')
+      .then((data: any) => (this.movies = JSON.stringify(data, null, 2)));
   }
 }

--- a/angular-app/tsconfig.json
+++ b/angular-app/tsconfig.json
@@ -16,10 +16,7 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "es2020",
-    "lib": [
-      "es2018",
-      "dom"
-    ]
+    "lib": ["es2018", "dom"]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 node_modules/
+dist/
 .warp
 
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,7 +1,0 @@
-const { fetchMovies } = require('./src/mongodb');
-
-const hello = () => {
-  return `Hello from ScaleDynamics Platform, MongoDB, Angular and Node.js ${process.version} !`;
-};
-
-module.exports = { hello, fetchMovies };

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,9 +1,18 @@
 {
   "name": "backend",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "src/index.ts",
   "license": "MIT",
+  "scripts": {
+    "ts-watch": "tsc --watch --preserveWatchOutput",
+    "ts-build": "tsc --build"
+  },
   "dependencies": {
     "mongodb": "^3.6.6"
+  },
+  "devDependencies": {
+    "@types/mongodb": "^3.6.19",
+    "@types/node": "^15.14.0",
+    "typescript": "^4.3.5"
   }
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,7 @@
+import { fetchMovies } from "./mongodb";
+
+const hello = async (): Promise<string> => {
+  return `Hello from ScaleDynamics Platform, MongoDB, Angular and Node.js ${process.version} !`;
+};
+
+export { hello, fetchMovies };

--- a/backend/src/mongodb.ts
+++ b/backend/src/mongodb.ts
@@ -1,15 +1,15 @@
-const { MongoClient } = require('mongodb');
+import { MongoClient } from 'mongodb';
 
 // connection URI
 const URI = 'mongodb+srv://test:test@movies-scqxj.gcp.mongodb.net/';
 
 // create & connect a new MongoDB client
-const connection = MongoClient(URI, {
+const connection = new MongoClient(URI, {
   useNewUrlParser: true,
   useUnifiedTopology: true,
 }).connect();
 
-const fetchMovies = async (search) => {
+const fetchMovies = async (search: string) => {
   // await database connection
   const client = await connection.catch((error) => {
     throw new Error(`Database connection failed (${error.message})`);
@@ -24,4 +24,5 @@ const fetchMovies = async (search) => {
     .limit(50)
     .toArray();
 };
-module.exports = { fetchMovies };
+
+export { fetchMovies }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "CommonJS",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "moduleResolution": "node",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/backend/warp.config.js
+++ b/backend/warp.config.js
@@ -4,4 +4,8 @@ module.exports = {
     projectPath: '../angular-app',
     name: 'backend',
   },
+  expose: {
+    source: 'dist/index.js',
+    type: 'dist/index.d.ts'
+  }
 };


### PR DESCRIPTION
The typescript build command is separated from the rest of the build and not sequentially build with the rest due to some side effect with the typescript compiler. Also there is now a return of the `prestart` instead of a `predeploy` script for selecting a project at the start and build the typescript into js to avoid issues with warp looking for a file.